### PR TITLE
"Bump codecov-action to v4 and update permissions in run-tests.yml"

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: frontend_challenge_2/challenges/k-taro56
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./frontend_challenge_2/challenges/k-taro56/coverage/lcov.info

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -47,8 +49,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: ./frontend_challenge_2/challenges/k-taro56/coverage/lcov.info
-          flags: unittests
-          name: codecov-umbrella
           fail_ci_if_error: true


### PR DESCRIPTION
This pull request updates the codecov-action to version 4 in the `.github/workflows/run-tests.yml` file. It also updates the permissions in the same file to include the `id-token: write` permission.